### PR TITLE
Stop scan before connect

### DIFF
--- a/lib/base/finder.js
+++ b/lib/base/finder.js
@@ -44,6 +44,10 @@ BaseFinder.prototype.createRobot = function(peripheral) {
 BaseFinder.prototype.connect = function(robot, callback) {
 	var self = this;
 	
+	// Stop scanning in order to connect to the MiP
+	// Reference: https://github.com/sandeepmistry/noble/issues/165#issuecomment-93594586
+	noble.stopScanning();
+
 	robot.connect(function(err) {
 		if (err == null) {
 			self.connectedRobots.push(robot);


### PR DESCRIPTION
Given a couple of sources found regarding the noble library:

* https://porter.io/github.com/sandeepmistry/noble
* https://github.com/sandeepmistry/noble/issues/165#issuecomment-93594586

Certain Bluetooth adapters cannot continue scanning while attempting to connect to a device. This change tells noble to stop scanning just prior to connecting to a robot.

I ran into this issue with my Dell Laptop with an Intel 3160AC combination Bluetooth 4.0/AC wireless card and the only way to get it to work was to tell noble to stop scanning just prior to the connect call. That is represented in this request. 

One thing I have yet to find is a disconnect routine where I would intend to tell noble to once again start scanning. 
